### PR TITLE
Code Cleanup and Typo Fix

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -70,7 +70,7 @@ class _MyHomePageState extends State<MyHomePage> {
               showLabel: false,
               notchColor: Colors.black87,
               bottomBarItems: [
-                const BottomBarItems(
+                const BottomBarItem(
                   inActiveItem: Icon(
                     Icons.home_filled,
                     color: Colors.blueGrey,
@@ -81,7 +81,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   ),
                   itemLabel: 'Page 1',
                 ),
-                const BottomBarItems(
+                const BottomBarItem(
                   inActiveItem: Icon(
                     Icons.star,
                     color: Colors.blueGrey,
@@ -94,7 +94,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 ),
 
                 ///svg example
-                BottomBarItems(
+                BottomBarItem(
                   inActiveItem: SvgPicture.asset(
                     'assets/search_icon.svg',
                     color: Colors.blueGrey,
@@ -105,7 +105,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   ),
                   itemLabel: 'Page 3',
                 ),
-                const BottomBarItems(
+                const BottomBarItem(
                   inActiveItem: Icon(
                     Icons.settings,
                     color: Colors.blueGrey,
@@ -116,7 +116,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   ),
                   itemLabel: 'Page 4',
                 ),
-                const BottomBarItems(
+                const BottomBarItem(
                   inActiveItem: Icon(
                     Icons.person,
                     color: Colors.blueGrey,

--- a/lib/src/bottom_bar_active_item.dart
+++ b/lib/src/bottom_bar_active_item.dart
@@ -5,33 +5,33 @@ import 'constants/constants.dart';
 class BottomBarActiveItem extends StatelessWidget {
   const BottomBarActiveItem(
     this.index, {
-    this.itemWidget,
-    this.scrollPosition,
-    this.onTap,
+    required this.itemWidget,
+    required this.onTap,
+    required this.scrollPosition,
   });
 
   /// item index
   final int index;
 
   /// item
-  final Widget? itemWidget;
+  final Widget itemWidget;
 
   /// Double value to indicate the item position
-  final double? scrollPosition;
+  final double scrollPosition;
 
   /// Function called when an item was tapped
-  final ValueChanged<int>? onTap;
+  final ValueChanged<int> onTap;
 
   @override
   Widget build(BuildContext context) {
-    final icon = itemWidget!;
+    final icon = itemWidget;
     return InkWell(
       child: SizedBox.fromSize(
         size: const Size(kIconSize, kIconSize),
         child: Opacity(
-            opacity: kPi * 2 * (scrollPosition! % 1) == 0 ? 1 : 0, child: icon),
+            opacity: kPi * 2 * (scrollPosition % 1) == 0 ? 1 : 0, child: icon),
       ),
-      onTap: () => onTap!(index),
+      onTap: () => onTap(index),
     );
   }
 }

--- a/lib/src/bottom_bar_inactive_item.dart
+++ b/lib/src/bottom_bar_inactive_item.dart
@@ -7,29 +7,29 @@ import 'constants/constants.dart';
 /// Class to generate the inactive icon on bottom bar
 class BottomBarInActiveItem extends StatelessWidget {
   const BottomBarInActiveItem(this.index,
-      {this.itemWidget,
+      {required this.itemWidget,
+      required this.onTap,
+      required this.showLabel,
       this.label,
-      this.onTap,
-      this.showLabel,
       this.labelStyle});
 
   /// item index
   final int index;
 
   /// item widget
-  final Widget? itemWidget;
+  final Widget itemWidget;
 
   /// String to indicate the label item
   final String? label;
 
   /// Boolean to show the item label
-  final bool? showLabel;
+  final bool showLabel;
 
   /// Value to indicate the label Style
   final TextStyle? labelStyle;
 
   /// Function called when an item was tapped
-  final ValueChanged<int>? onTap;
+  final ValueChanged<int> onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -39,8 +39,8 @@ class BottomBarInActiveItem extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            SizedBox(height: kIconSize, width: kIconSize, child: itemWidget!),
-            if (label != null && showLabel!) ...[
+            SizedBox(height: kIconSize, width: kIconSize, child: itemWidget),
+            if (label != null && showLabel) ...[
               const SizedBox(height: 5.0),
               Text(
                 label!,
@@ -53,7 +53,7 @@ class BottomBarInActiveItem extends StatelessWidget {
             ],
           ],
         ),
-        onTap: () => onTap!(index),
+        onTap: () => onTap(index),
       ),
     );
   }

--- a/lib/src/bottom_bar_inactive_item.dart
+++ b/lib/src/bottom_bar_inactive_item.dart
@@ -5,8 +5,8 @@ import 'package:flutter/material.dart';
 import 'constants/constants.dart';
 
 /// Class to generate the inactive icon on bottom bar
-class BottomBarUnActiveItem extends StatelessWidget {
-  const BottomBarUnActiveItem(this.index,
+class BottomBarInActiveItem extends StatelessWidget {
+  const BottomBarInActiveItem(this.index,
       {this.itemWidget,
       this.label,
       this.onTap,

--- a/lib/src/bottom_bar_painter.dart
+++ b/lib/src/bottom_bar_painter.dart
@@ -7,37 +7,37 @@ import 'constants/constants.dart';
 class BottomBarPainter extends CustomPainter {
   BottomBarPainter(
       {required this.position,
-      this.color,
-      this.showShadow,
+      required this.color,
+      required this.showShadow,
       required this.notchColor})
       : _paint = Paint()
-          ..color = color ?? Colors.white
+          ..color = color
           ..isAntiAlias = true,
         _shadowColor = Colors.grey.shade600,
         _notchPaint = Paint()
-          ..color = notchColor ?? color ?? Colors.white
+          ..color = notchColor
           ..isAntiAlias = true;
 
   /// position
-  final double? position;
+  final double position;
 
   /// Color for the bottom bar
-  final Color? color;
+  final Color color;
 
   /// Paint value to custom painter
-  final Paint? _paint;
+  final Paint _paint;
 
   /// Shadow Color
-  final Color? _shadowColor;
+  final Color _shadowColor;
 
   /// Boolean to show shadow
-  final bool? showShadow;
+  final bool showShadow;
 
   /// Paint Value of notch
-  final Paint? _notchPaint;
+  final Paint _notchPaint;
 
   /// Color for the notch
-  final Color? notchColor;
+  final Color notchColor;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -59,7 +59,7 @@ class BottomBarPainter extends CustomPainter {
 
     final path = Path()
       ..moveTo(left + kTopRadius, top)
-      ..lineTo(position! - kTopRadius, top)
+      ..lineTo(position - kTopRadius, top)
       ..relativeArcToPoint(
         const Offset(kTopRadius, kTopRadius),
         radius: const Radius.circular(kTopRadius),
@@ -93,10 +93,10 @@ class BottomBarPainter extends CustomPainter {
         const Offset(kTopRadius, -kTopRadius),
         radius: const Radius.circular(kTopRadius),
       );
-    if (this.showShadow!) {
-      canvas..drawShadow(path, _shadowColor!, 5.0, true);
+    if (this.showShadow) {
+      canvas..drawShadow(path, _shadowColor, 5.0, true);
     }
-    canvas.drawPath(path, _paint!);
+    canvas.drawPath(path, _paint);
   }
 
   /// Function used to draw the circular indicator
@@ -105,7 +105,7 @@ class BottomBarPainter extends CustomPainter {
       ..addArc(
         Rect.fromCircle(
           center: Offset(
-            position! + kCircleMargin + kCircleRadius,
+            position + kCircleMargin + kCircleRadius,
             kMargin + kCircleMargin,
           ),
           radius: kCircleRadius,
@@ -113,9 +113,9 @@ class BottomBarPainter extends CustomPainter {
         0,
         kPi * 2,
       );
-    if (this.showShadow!) {
-      canvas..drawShadow(path, _shadowColor!, 5.0, true);
+    if (this.showShadow) {
+      canvas..drawShadow(path, _shadowColor, 5.0, true);
     }
-    canvas.drawPath(path, _notchPaint!);
+    canvas.drawPath(path, _notchPaint);
   }
 }

--- a/lib/src/models/bottom_bar_item_model.dart
+++ b/lib/src/models/bottom_bar_item_model.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-class BottomBarItems {
-  const BottomBarItems({
+class BottomBarItem {
+  const BottomBarItem({
     this.inActiveItem,
     this.activeItem,
     this.itemLabel,

--- a/lib/src/models/bottom_bar_item_model.dart
+++ b/lib/src/models/bottom_bar_item_model.dart
@@ -2,16 +2,16 @@ import 'package:flutter/material.dart';
 
 class BottomBarItem {
   const BottomBarItem({
-    this.inActiveItem,
-    this.activeItem,
+    required this.inActiveItem,
+    required this.activeItem,
     this.itemLabel,
   });
 
   /// Selected bottom bar item
-  final Widget? inActiveItem;
+  final Widget inActiveItem;
 
   /// Un selected bottom bar item
-  final Widget? activeItem;
+  final Widget activeItem;
 
   /// bottom bar item label
   final String? itemLabel;

--- a/lib/src/notch_bottom_bar.dart
+++ b/lib/src/notch_bottom_bar.dart
@@ -23,25 +23,25 @@ class AnimatedNotchBottomBar extends StatefulWidget {
   final Color color;
 
   /// Boolean to show shadow
-  final bool? showShadow;
+  final bool showShadow;
 
   /// Boolean to show bottom text
-  final bool? showLabel;
+  final bool showLabel;
 
   /// TextStyle to show bottom text
   final TextStyle? itemLabelStyle;
 
   ///Boolean to show blur effect
-  final bool? showBlurBottomBar;
+  final bool showBlurBottomBar;
 
   ///Opacity
-  final double? blurOpacity;
+  final double blurOpacity;
 
   /// Filter X
-  final double? blurFilterX;
+  final double blurFilterX;
 
   /// Filter Y
-  final double? blurFilterY;
+  final double blurFilterY;
 
   /// Color of bottom bar
   final Color notchColor;
@@ -114,17 +114,16 @@ class _AnimatedNotchBottomBarState extends State<AnimatedNotchBottomBar> {
                     children: <Widget>[
                       BackdropFilter(
                         filter: ImageFilter.blur(
-                          sigmaX: widget.showBlurBottomBar!
-                              ? widget.blurFilterX!
+                          sigmaX: widget.showBlurBottomBar
+                              ? widget.blurFilterX
                               : 0.0,
-                          sigmaY: widget.showBlurBottomBar!
-                              ? widget.blurFilterY!
+                          sigmaY: widget.showBlurBottomBar
+                              ? widget.blurFilterY
                               : 0.0,
                         ),
                         child: Opacity(
-                          opacity: widget.showBlurBottomBar!
-                              ? widget.blurOpacity!
-                              : 1,
+                          opacity:
+                              widget.showBlurBottomBar ? widget.blurOpacity : 1,
                           child: CustomPaint(
                             size: Size(width, height),
                             painter: BottomBarPainter(

--- a/lib/src/notch_bottom_bar.dart
+++ b/lib/src/notch_bottom_bar.dart
@@ -155,7 +155,7 @@ class _AnimatedNotchBottomBarState extends State<AnimatedNotchBottomBar> {
                           Positioned(
                             top: kMargin + (kHeight - kCircleRadius * 2) / 2,
                             left: kCircleMargin + _itemPosByIndex(i),
-                            child: BottomBarUnActiveItem(i,
+                            child: BottomBarInActiveItem(i,
                                 itemWidget:
                                     widget.bottomBarItems[i].inActiveItem!,
                                 label: widget.bottomBarItems[i].itemLabel,

--- a/lib/src/notch_bottom_bar.dart
+++ b/lib/src/notch_bottom_bar.dart
@@ -11,13 +11,13 @@ import 'models/bottom_bar_item_model.dart';
 /// Class to generate the NotchBottomBar
 class AnimatedNotchBottomBar extends StatefulWidget {
   /// Controller for animation
-  final PageController? pageController;
+  final PageController pageController;
 
   /// List of items of bottom bar
-  final List<BottomBarItems>? bottomBarItems;
+  final List<BottomBarItems> bottomBarItems;
 
   /// Function called when an item was tapped
-  final ValueChanged<int>? onTap;
+  final ValueChanged<int> onTap;
 
   /// Color of bottom bar
   final Color color;
@@ -79,11 +79,10 @@ class _AnimatedNotchBottomBarState extends State<AnimatedNotchBottomBar> {
   @override
   Widget build(BuildContext context) {
     /// throws exception if list length is more then 5
-    if (widget.bottomBarItems!.length > 5) {
-      throw Exception(' Bottom bar item length should not be more then 5');
+    if (widget.bottomBarItems.length > 5) {
+      throw Exception(' Bottom bar item length should not be more than 5');
     }
-    if (widget.pageController!.initialPage >
-        widget.bottomBarItems!.length - 1) {
+    if (widget.pageController.initialPage > widget.bottomBarItems.length - 1) {
       throw Exception(
           ' Initial page index cannot be higher than bottom bar items length');
     }
@@ -92,19 +91,19 @@ class _AnimatedNotchBottomBarState extends State<AnimatedNotchBottomBar> {
     final width = size.width;
     const height = kHeight + kMargin * 2;
 
-    return widget.bottomBarItems!.length > maxCount
+    return widget.bottomBarItems.length > maxCount
         ? Container()
         : AnimatedBuilder(
-            animation: widget.pageController!,
+            animation: widget.pageController,
             builder: (BuildContext _, Widget? child) {
               ///to set any initial page
               double scrollPosition =
-                  widget.pageController!.initialPage.toDouble();
-              int currentIndex = widget.pageController!.initialPage;
+                  widget.pageController.initialPage.toDouble();
+              int currentIndex = widget.pageController.initialPage;
 
-              if (widget.pageController?.hasClients ?? false) {
-                scrollPosition = widget.pageController!.page!;
-                currentIndex = (widget.pageController!.page! + 0.5).toInt();
+              if (widget.pageController.hasClients) {
+                scrollPosition = widget.pageController.page!;
+                currentIndex = (widget.pageController.page! + 0.5).toInt();
               }
 
               return ClipRRect(
@@ -138,7 +137,7 @@ class _AnimatedNotchBottomBarState extends State<AnimatedNotchBottomBar> {
                         ),
                       ),
                       for (var i = 0;
-                          i < widget.bottomBarItems!.length;
+                          i < widget.bottomBarItems.length;
                           i++) ...[
                         if (i == currentIndex)
                           Positioned(
@@ -148,7 +147,7 @@ class _AnimatedNotchBottomBarState extends State<AnimatedNotchBottomBar> {
                                 _itemPosByScrollPosition(scrollPosition),
                             child: BottomBarActiveItem(
                               i,
-                              itemWidget: widget.bottomBarItems![i].activeItem,
+                              itemWidget: widget.bottomBarItems[i].activeItem,
                               scrollPosition: scrollPosition,
                               onTap: widget.onTap,
                             ),
@@ -159,8 +158,8 @@ class _AnimatedNotchBottomBarState extends State<AnimatedNotchBottomBar> {
                             left: kCircleMargin + _itemPosByIndex(i),
                             child: BottomBarUnActiveItem(i,
                                 itemWidget:
-                                    widget.bottomBarItems![i].inActiveItem!,
-                                label: widget.bottomBarItems![i].itemLabel,
+                                    widget.bottomBarItems[i].inActiveItem!,
+                                label: widget.bottomBarItems[i].itemLabel,
                                 onTap: widget.onTap,
                                 showLabel: widget.showLabel,
                                 labelStyle: widget.itemLabelStyle),
@@ -186,7 +185,7 @@ class _AnimatedNotchBottomBarState extends State<AnimatedNotchBottomBar> {
 
   double _itemDistance() {
     return (_lastItemPosition() - _firstItemPosition()) /
-        (widget.bottomBarItems!.length - 1);
+        (widget.bottomBarItems.length - 1);
   }
 
   double _itemPosByScrollPosition(double scrollPosition) {

--- a/lib/src/notch_bottom_bar.dart
+++ b/lib/src/notch_bottom_bar.dart
@@ -14,7 +14,7 @@ class AnimatedNotchBottomBar extends StatefulWidget {
   final PageController pageController;
 
   /// List of items of bottom bar
-  final List<BottomBarItems> bottomBarItems;
+  final List<BottomBarItem> bottomBarItems;
 
   /// Function called when an item was tapped
   final ValueChanged<int> onTap;

--- a/lib/src/notch_bottom_bar.dart
+++ b/lib/src/notch_bottom_bar.dart
@@ -157,7 +157,7 @@ class _AnimatedNotchBottomBarState extends State<AnimatedNotchBottomBar> {
                             left: kCircleMargin + _itemPosByIndex(i),
                             child: BottomBarInActiveItem(i,
                                 itemWidget:
-                                    widget.bottomBarItems[i].inActiveItem!,
+                                    widget.bottomBarItems[i].inActiveItem,
                                 label: widget.bottomBarItems[i].itemLabel,
                                 onTap: widget.onTap,
                                 showLabel: widget.showLabel,

--- a/lib/src/notch_bottom_bar.dart
+++ b/lib/src/notch_bottom_bar.dart
@@ -67,7 +67,7 @@ class AnimatedNotchBottomBar extends StatefulWidget {
 }
 
 class _AnimatedNotchBottomBarState extends State<AnimatedNotchBottomBar> {
-  double? _screenWidth;
+  late double _screenWidth;
   int maxCount = 5;
 
   @override
@@ -173,12 +173,12 @@ class _AnimatedNotchBottomBarState extends State<AnimatedNotchBottomBar> {
   }
 
   double _firstItemPosition() {
-    return (_screenWidth! - kMargin * 2) * 0.1;
+    return (_screenWidth - kMargin * 2) * 0.1;
   }
 
   double _lastItemPosition() {
-    return _screenWidth! -
-        (_screenWidth! - kMargin * 2) * 0.1 -
+    return _screenWidth -
+        (_screenWidth - kMargin * 2) * 0.1 -
         (kCircleRadius + kCircleMargin) * 2;
   }
 


### PR DESCRIPTION
I renamed BottomBarItems to BottomBarItem because it is just a single item. It don't need to be plural. Also I renamed BottomBarUnActiveItem to BottomBarInActiveItem which is a clear typo.
I cleaned the project which has a lot of bang operator and nullable types. They are verbose because after declaration of fields they are casting to the non nullable form with the bang operator.
Bang Operator -> !