### PR TITLE
control item size

### DIFF
--- a/lib/src/bottom_bar_inactive_item.dart
+++ b/lib/src/bottom_bar_inactive_item.dart
@@ -17,6 +17,7 @@ class BottomBarInActiveItem extends StatelessWidget {
     this.textOverflow,
     this.textAlign,
     this.textDirection,
+    this.itemSize,
   });
 
   /// item index
@@ -55,6 +56,8 @@ class BottomBarInActiveItem extends StatelessWidget {
   /// Function called when an item was tapped
   final ValueChanged<int> onTap;
 
+  final Size? itemSize;
+
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
@@ -62,7 +65,7 @@ class BottomBarInActiveItem extends StatelessWidget {
       child: Container(
         color: Colors.transparent,
         child: SizedBox.fromSize(
-          size: const Size(kCircleRadius * 2, kCircleRadius * 2),
+          size: itemSize ?? const Size(kCircleRadius * 2, kCircleRadius * 2),
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[

--- a/lib/src/constants/constants.dart
+++ b/lib/src/constants/constants.dart
@@ -5,7 +5,7 @@ double kMargin = 14.0;
 double kHeight = 62.0;
 
 /// notch circle circle radius
-const double kCircleRadius = 30.0;
+const double kCircleRadius = 45.0;
 
 /// margin between notch and circle
 const double kCircleMargin = 8.0;

--- a/lib/src/constants/constants.dart
+++ b/lib/src/constants/constants.dart
@@ -5,7 +5,7 @@ double kMargin = 14.0;
 double kHeight = 62.0;
 
 /// notch circle circle radius
-const double kCircleRadius = 45.0;
+const double kCircleRadius = 30.0;
 
 /// margin between notch and circle
 const double kCircleMargin = 8.0;

--- a/lib/src/notch_bottom_bar.dart
+++ b/lib/src/notch_bottom_bar.dart
@@ -55,6 +55,8 @@ class AnimatedNotchBottomBar extends StatefulWidget {
 
   final double kBottomRadius;
 
+  final Size? itemSize;
+
   /// set the maxLine of item label
   final int? maxLine;
 
@@ -110,6 +112,7 @@ class AnimatedNotchBottomBar extends StatefulWidget {
     this.shadowElevation,
     this.showShadow = true,
     this.showLabel = true,
+    this.itemSize,
     required this.kBottomRadius,
     this.notchShader,
     this.showBlurBottomBar = false,
@@ -263,6 +266,7 @@ class _AnimatedNotchBottomBarState extends State<AnimatedNotchBottomBar> with Si
                               textDirection: widget.textDirection,
                               textAlign: widget.textAlign,
                               maxLine: widget.maxLine,
+                              itemSize: widget.itemSize,
                               itemWidget: widget.bottomBarItems[i].inActiveItem,
                               labelWidget: widget.bottomBarItems[i].itemLabelWidget,
                               label: widget.bottomBarItems[i].itemLabel,


### PR DESCRIPTION
my use case for this package was having 3 items only in the bottom navigation bar yet the item width was limited to 60 with no way to control it which resulted in an overflow, i just added a property called itemSize with allows to control specifically the label size.